### PR TITLE
Bump schema and optionally log to file

### DIFF
--- a/config/ecasbot.json
+++ b/config/ecasbot.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "tgkey": "",
   "admins": [],
   "restent": ["url", "text_link", "mention"],
@@ -7,5 +7,6 @@
   "bantime": 1209600,
   "maxname": 75,
   "chkrgx": "(.*VX.*QQ.+)",
-  "urlrgx": "(https?)"
+  "urlrgx": "(https?)",
+  "logtofile": ""
 }

--- a/ecasbot/__init__.py
+++ b/ecasbot/__init__.py
@@ -21,6 +21,7 @@ import emoji
 import logging
 import re
 import time
+import sys
 import telebot
 
 from .settings import Settings
@@ -213,7 +214,7 @@ class ASBot:
 
     def __init__(self):
         logging.basicConfig(level=logging.INFO)
-        self.__schema = 1
+        self.__schema = 2
         self.__logger = logging.getLogger(__name__)
         self.__settings = Settings(self.__schema)
         self.__msgs = {
@@ -235,4 +236,7 @@ class ASBot:
         }
         if not self.__settings.tgkey:
             raise Exception(self.__msgs['as_notoken'])
+        if self.__settings.logtofile:
+            self.__logger.addHandler(logging.FileHandler(self.__settings.logtofile))
+        self.__logger.addHandler(logging.StreamHandler(sys.stdout))
         self.bot = telebot.TeleBot(self.__settings.tgkey)

--- a/ecasbot/settings.py
+++ b/ecasbot/settings.py
@@ -24,6 +24,10 @@ import os
 
 class Settings:
     @property
+    def logtofile(self) -> str:
+        return self.__data['logtofile']
+
+    @property
     def tgkey(self) -> str:
         return self.__data['tgkey']
 


### PR DESCRIPTION
Add an option to log bot output to file.

This is useful for k8s installs, where the log is stored on the volume and being displayed by web server on specific URL - e.g. https://ii-stage.vrutkovs.eu/bot.log