### PR TITLE
Log details of removed messages in debug output

### DIFF
--- a/ecasbot/__init__.py
+++ b/ecasbot/__init__.py
@@ -429,8 +429,20 @@ class ASBot:
             """
             try:
                 # Removing messages from restricted members...
-                if self.__check_message_entities(message) or self.__check_message_forward(
-                        message) or self.__check_message_spam(message):
+                entities = self.__check_message_entities(message)
+                forward = self.__check_message_forward(message)
+                spam = self.__check_message_spam(message)
+                author_name = "{} - {} {}".format(message.from_user.id,
+                                                  message.from_user.first_name, message.from_user.last_name)
+
+                self.__logger.debug("chat: {} ({}) ".format(message.chat.id, message.chat.title))
+                self.__logger.debug("author: {} ".format(author_name))
+                self.__logger.debug("message: {} ".format(message.text))
+                self.__logger.debug("entities: {}".format(entities))
+                self.__logger.debug("forward: {}".format(forward))
+                self.__logger.debug("spam: {}".format(spam))
+
+                if entities or forward or spam:
                     self.bot.delete_message(message.chat.id, message.message_id)
                     self.__logger.info(
                         self.__msgs['as_msgrest'].format(message.from_user.first_name, message.from_user.id,


### PR DESCRIPTION
Store some details of removed message - chat id and title, author, message, forward/spam status - in debug logs so that rules could be tweaked later on