### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.fedoraproject.org/fedora:32
+
+RUN dnf install -y python3-pip && dnf clean all
+
+COPY . .
+RUN pip3 install -r requirements.txt && \
+    python3 setup.py install
+
+CMD ["/usr/local/bin/ecasbot"]


### PR DESCRIPTION
Dockerfile для сборки ecasbot в контейнере. См. https://quay.io/repository/vrutkovs/ecasbot?tab=builds

Ref: https://github.com/RussianFedora/server-config/issues/14